### PR TITLE
Add classeviva automation

### DIFF
--- a/automations/classeviva.sh
+++ b/automations/classeviva.sh
@@ -1,0 +1,11 @@
+[ -z ${CLASSEVIVA_USERNAME} ] && echo "CLASSEVIVA_USERNAME is not set" && return
+[ -z ${CLASSEVIVA_PASSWORD} ] && echo "CLASSEVIVA_PASSWORD is not set" && return
+[ -z ${TELEGRAM_TOKEN} ] && echo "TELEGRAM_TOKEN is not set" && return
+[ -z ${CHAT_ID} ] && echo "CHAT_ID is not set" && return
+
+classeviva grades list --limit 10 --format json > classeviva.json
+
+cat classeviva.json \
+    | jq '{"grades": .}' \
+    | jinja -d - -f json templates/classeviva/grades.j2 \
+    | tgm message send --chat-id ${CHAT_ID}

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ set -e
 [ -z ${AUTOMATOR_HOME} ] && echo "AUTOMATOR_HOME is not set" && exit 1
 
 # Add non-Python tools to the PATH.
-export PATH=$PATH/tools
+export PATH=$PATH:$AUTOMATOR_HOME/tools
 
 [ $# -eq 0 ] && echo "No arguments provided" && exit 1
 

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,9 @@ set -e
 
 [ -z ${AUTOMATOR_HOME} ] && echo "AUTOMATOR_HOME is not set" && exit 1
 
+# Add non-Python tools to the PATH.
+export PATH=$PATH/tools
+
 [ $# -eq 0 ] && echo "No arguments provided" && exit 1
 
 AUTOMATION=$1

--- a/templates/classeviva/grades.j2
+++ b/templates/classeviva/grades.j2
@@ -1,0 +1,10 @@
+## Classeviva
+
+Ultimi 10 voti (in ordine cronologico):
+
+{% for date, items in grades|groupby("evtDate") -%}
+{{ date }}:
+{% for grade in items -%}
+- {{ grade.displayValue }}{% if grade.color == "blue" %} (blu){% endif %} {{ grade.subjectDesc }}{% if grade.notesForFamily %} — {{ grade.notesForFamily }}{% endif %}
+{% endfor %}
+{% endfor %}

--- a/tools/tools.md
+++ b/tools/tools.md
@@ -1,0 +1,4 @@
+# Tools
+
+This directory contains the non-Python tools required to run automations.
+


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want to add a new automation that posts the last 10 grades from Classeviva to a Telegram group.

### Change description
<!-- What does your code do? -->

Add a new automation script to fetch the data from Classeviva and a message template to group by the grades by date.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.